### PR TITLE
fix udev rule for Ubuntu

### DIFF
--- a/70-u2f.rules
+++ b/70-u2f.rules
@@ -1,1 +1,1 @@
-KERNEL=="hidraw*", SUBSYSTEM=="hidraw", MODE="0664", GROUP="plugdev", ATTRS{idVendor}=="1050", ATTRS{idProduct}=="0113|0114|115|116|120"
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", MODE="0664", GROUP="plugdev", ATTRS{idVendor}=="1050", ATTRS{idProduct}=="0113|0114|0115|0116|0120"


### PR DESCRIPTION
udev didn't allow me to use this rule as-is, I had to add the leading 0 to the 0120. Maybe it wasn't optional in older versions of udev, I dunno, but this fixed it for me.

Discussion:
http://forum.yubico.com/viewtopic.php?f=33&t=1545&p=5991#p5991
http://forum.yubico.com/viewtopic.php?f=26&t=1535&p=5996#p5996
