### PR TITLE
Fix idProduct match for udev rules

### DIFF
--- a/70-u2f.rules
+++ b/70-u2f.rules
@@ -1,1 +1,1 @@
-KERNEL=="hidraw*", SUBSYSTEM=="hidraw", MODE="0664", GROUP="plugdev", ATTRS{idVendor}=="1050", ATTRS{idProduct}=="0113|0114|115|116|120"
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", MODE="0664", GROUP="plugdev", ATTRS{idVendor}=="1050", ATTRS{idProduct}=="0113|0114|0115|0116|0120"


### PR DESCRIPTION
The leading 0 is not optional, needs to be there or 0115 (NEO-n in U2F+CCID mode) will not be matched.
