### PR TITLE
Don't return success from u2fh_{register/authenticate} without also setting response output argument

### DIFF
--- a/u2f-host/authenticate.c
+++ b/u2f-host/authenticate.c
@@ -222,7 +222,8 @@ u2fh_authenticate (u2fh_devs * devs,
   if (len != 2)
     {
       prepare_response (buf, len - 2, bd, challenge, response);
+      return U2FH_OK;
     }
 
-  return U2FH_OK;
+  return U2FH_TRANSPORT_ERROR;
 }

--- a/u2f-host/register.c
+++ b/u2f-host/register.c
@@ -170,6 +170,7 @@ u2fh_register (u2fh_devs * devs,
   if (len != 2)
     {
       prepare_response (buf, len - 2, bd, response);
+      return U2FH_OK;
     }
-  return U2FH_OK;
+  return U2FH_TRANSPORT_ERROR;
 }


### PR DESCRIPTION
Without this change it was possible to get U2FH_OK return code from both of those function and get response output variable pointing to random memory, that when it was accessed later did lead to SIGSEGV.