### PR TITLE
Enable out of src tree builds.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -14,7 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 AM_CFLAGS = $(WARN_CFLAGS)
-AM_CPPFLAGS=-I$(top_srcdir)/u2f-host -I$(top_builddir)
+AM_CPPFLAGS=-I$(top_srcdir)/u2f-host -I$(top_builddir) -I$(top_builddir)/u2f-host
 
 bin_PROGRAMS = u2f-host
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -14,7 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 AM_CFLAGS = $(WARN_CFLAGS)
-AM_CPPFLAGS=-I$(top_srcdir)/u2f-host -I$(top_builddir)
+AM_CPPFLAGS=-I$(top_srcdir)/u2f-host -I$(top_builddir) -I$(top_builddir)/u2f-host
 
 AM_LDFLAGS = -no-install
 LDADD = ../u2f-host/libu2f-host.la


### PR DESCRIPTION
u2f-host-version.h is dynamically generated so the
$(top_builddir)/u2f-host needs to be added to AM_CPPFLAGS.