### PR TITLE
Make send_apdu send data like chrome does

### DIFF
--- a/u2f-host/u2fmisc.c
+++ b/u2f-host/u2fmisc.c
@@ -326,9 +326,10 @@ send_apdu (u2fh_devs * devs, int index, int cmd, const unsigned char *d,
   sprintf (data, "%c%c%c%c%c%c%c", 0, cmd, p1, 0, 0, (dlen >> 8) & 0xff,
 	   dlen & 0xff);
   memcpy (data + RESPHEAD_SIZE, d, dlen);
+  memset (data + RESPHEAD_SIZE + dlen, 0, 2);
 
   rc =
-    u2fh_sendrecv (devs, index, U2FHID_MSG, data, RESPHEAD_SIZE + dlen, out,
+    u2fh_sendrecv (devs, index, U2FHID_MSG, data, RESPHEAD_SIZE + dlen + 2, out,
 		   outlen);
   if (rc != U2FH_OK)
     {


### PR DESCRIPTION
I can't find in specification reason for that but Chrome does send two 0 bytes after each apdu packet, and without some devices (NeoWave Keydo AES and HyperFido) return error when receiving such data.

I tested this change with two other devices that still work after that change like they worked before (Yubico NEO and Keydo).