### PR TITLE
Don't release json object that we don't own no more

### DIFF
--- a/u2f-host/authenticate.c
+++ b/u2f-host/authenticate.c
@@ -67,9 +67,11 @@ prepare_response2 (const char *encstr, const char *bdstr, const char *input,
 
 done:
   json_object_put (jo);
-  json_object_put (enc);
-  json_object_put (bd);
-  json_object_put (key);
+  if (!jo) {
+    json_object_put (enc);
+    json_object_put (bd);
+    json_object_put (key);
+  }
 
   return rc;
 }

--- a/u2f-host/register.c
+++ b/u2f-host/register.c
@@ -51,8 +51,10 @@ prepare_response2 (const char *respstr, const char *bdstr, char **response)
 
 done:
   json_object_put (jo);
-  json_object_put (resp);
-  json_object_put (bd);
+  if (!jo) {
+    json_object_put (resp);
+    json_object_put (bd);
+  }
 
   return rc;
 }

--- a/u2f-host/u2fmisc.c
+++ b/u2f-host/u2fmisc.c
@@ -93,9 +93,11 @@ prepare_browserdata (const char *challenge, const char *origin,
 
 done:
   json_object_put (jo);
-  json_object_put (chal);
-  json_object_put (orig);
-  json_object_put (typ);
+  if (!jo) {
+    json_object_put (chal);
+    json_object_put (orig);
+    json_object_put (typ);
+  }
   return rc;
 }
 


### PR DESCRIPTION
json_object_object_add() takes ownership of object put inside, and calling
json_obj_put() on those leads to using already freed memory.