### PR TITLE
Don't do memcmp on uninitialized memory

### DIFF
--- a/u2f-host/authenticate.c
+++ b/u2f-host/authenticate.c
@@ -205,7 +205,6 @@ u2fh_authenticate (u2fh_devs * devs,
 	    {
 	      skipped++;
 	      skip_devices[i] = 2;
-	      continue;
 	    }
 	  memcpy (buf, tmp_buf, len);
 	}


### PR DESCRIPTION
If device is returning 2 byte response that is not equal to NOTSATISFIED,
buf content may be not initialized and memcmp inside while() will just
check against some random value that was on stack.