### PR TITLE
use unsigned ints to prevent buffer overflows, added support for u2f commands

### DIFF
--- a/src/cmdline.ggo
+++ b/src/cmdline.ggo
@@ -17,7 +17,7 @@ package "u2f-host"
 purpose "Perform U2F host-side operations on the command line. Reads challenge from standard input and writes a response to standard output."
 
 option "origin" o "Origin URL to use." string optional
-option "action" a "Action to take." values="register","authenticate","sendrecv" enum
+option "action" a "Action to take." values="register","authenticate","sendrecv","wink","ping" enum
 option "touch" t "Invert user-presence flag (on by default)" flag off
 option "debug" d "Print debug information to standard error" flag off
 option "command" c "Command for sendrecv action" string optional

--- a/src/u2f-host.c
+++ b/src/u2f-host.c
@@ -25,6 +25,7 @@
 #include <string.h>
 
 #include "cmdline.h"
+#include "inc/u2f_hid.h"
 
 int
 main (int argc, char *argv[])
@@ -111,6 +112,24 @@ main (int argc, char *argv[])
 				   args_info.touch_flag ? 0 :
 				   U2FH_REQUEST_USER_PRESENCE);
 	}
+      break;
+    case action_arg_wink:
+      {
+	unsigned char out[2048];
+	size_t outlen = sizeof (out);
+	rc =
+	  u2fh_sendrecv (devs, 0, U2FHID_WINK, challenge, chal_len, out,
+			 &outlen);
+      }
+      break;
+    case action_arg_ping:
+      {
+	unsigned char out[2048];
+	size_t outlen = sizeof (out);
+	rc =
+	  u2fh_sendrecv (devs, 0, U2FHID_PING, challenge, chal_len, out,
+			 &outlen);
+      }
       break;
     case action_arg_sendrecv:
       {

--- a/u2f-host/u2fmisc.c
+++ b/u2f-host/u2fmisc.c
@@ -167,7 +167,7 @@ u2fh_sendrecv (u2fh_devs * devs, unsigned index, uint8_t cmd,
       U2FHID_FRAME frame = { 0 };
       {
 	int len = sendlen - datasent;
-	int maxlen;
+	unsigned int maxlen;
 	unsigned char *data;
 	frame.cid = dev->cid;
 	if (datasent == 0)
@@ -218,7 +218,7 @@ u2fh_sendrecv (u2fh_devs * devs, unsigned index, uint8_t cmd,
     U2FHID_FRAME frame;
     unsigned char data[HID_RPT_SIZE];
     int len = HID_RPT_SIZE;
-    int maxlen = *recvlen;
+    unsigned int maxlen = *recvlen;
     int recvddata = 0;
     short datalen;
     int timeout = HID_TIMEOUT;


### PR DESCRIPTION
maxlen gets input length from outside packet which could be a negative number, foiling the bounds checking.