### PR TITLE
use unsigned ints to prevent buffer overflows

### DIFF
--- a/u2f-host/u2fmisc.c
+++ b/u2f-host/u2fmisc.c
@@ -220,7 +220,7 @@ u2fh_sendrecv (u2fh_devs * devs, unsigned index, uint8_t cmd,
     int len = HID_RPT_SIZE;
     unsigned int maxlen = *recvlen;
     int recvddata = 0;
-    short datalen;
+    unsigned short datalen;
     int timeout = HID_TIMEOUT;
     int rc = 0;
 

--- a/u2f-host/u2fmisc.c
+++ b/u2f-host/u2fmisc.c
@@ -167,7 +167,7 @@ u2fh_sendrecv (u2fh_devs * devs, unsigned index, uint8_t cmd,
       U2FHID_FRAME frame = { 0 };
       {
 	int len = sendlen - datasent;
-	int maxlen;
+	unsigned int maxlen;
 	unsigned char *data;
 	frame.cid = dev->cid;
 	if (datasent == 0)
@@ -218,7 +218,7 @@ u2fh_sendrecv (u2fh_devs * devs, unsigned index, uint8_t cmd,
     U2FHID_FRAME frame;
     unsigned char data[HID_RPT_SIZE];
     int len = HID_RPT_SIZE;
-    int maxlen = *recvlen;
+    unsigned int maxlen = *recvlen;
     int recvddata = 0;
     short datalen;
     int timeout = HID_TIMEOUT;


### PR DESCRIPTION
max len is compared to outside input (from the u2f device) and could be a negative number which would foil the bounds checking.