### PR TITLE
Add udev rules for Feitian ePass FIDO

### DIFF
--- a/70-u2f.rules
+++ b/70-u2f.rules
@@ -13,4 +13,7 @@ KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1e0d", ATTRS{idProduct
 # HyperSecu HyperFIDO
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="096e", ATTRS{idProduct}=="0880", TAG+="uaccess"
 
+# Feitian ePass FIDO
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="096e", ATTRS{idProduct}=="0850", TAG+="uaccess"
+
 LABEL="u2f_end"


### PR DESCRIPTION
These devices: http://en.ftsafe.com/product/ePass_FIDO_Authenitcation

I note that this and the HyperSecu device are both from vendor 096e. These rules could be collapsed, but I've chosen to keep them separate for clarity.