### PR TITLE
Add ePass FIDO support

### DIFF
--- a/70-u2f.rules
+++ b/70-u2f.rules
@@ -19,4 +19,7 @@ KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="096e", ATTRS{idProduct
 # JaCarta U2F
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="24dc", ATTRS{idProduct}=="0101", TAG+="uaccess"
 
+# HS ePass FIDO
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="096e", ATTRS{idProduct}=="0850", TAG+="uaccess"
+
 LABEL="u2f_end"


### PR DESCRIPTION
This patch adds support for HS ePass fido (http://www.key-id.com/)