### PR TITLE
Add VASCO SecureClick USB Bridge

### DIFF
--- a/70-u2f.rules
+++ b/70-u2f.rules
@@ -37,4 +37,7 @@ KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="24dc", ATTRS{idProduct
 # U2F Zero
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="8acf", TAG+="uaccess"
 
+# VASCO SeccureClick
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1a44", ATTRS{idProduct}=="00bb", TAG+="uaccess"
+
 LABEL="u2f_end"


### PR DESCRIPTION
Add VASCO SecureClick USB Bridge. This only works after a SecureClick token was paired to the USB Bridge using the [Chrome app](https://chrome.google.com/webstore/detail/digipass-secureclick-mana/gjbcaijefcocakonhdnfhomcnlcppbcg). Before pairing, `idProduct` will be `80bb` and this rule will not fire.