### PR TITLE
Add Feitian's Multipass to the udev rules

### DIFF
--- a/70-u2f.rules
+++ b/70-u2f.rules
@@ -43,4 +43,7 @@ KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1a44", ATTRS{idProduct
 # Bluink Key
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="2abe", ATTRS{idProduct}=="1002", TAG+="uaccess"
 
+# Feitian Multipass
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="096e", ATTRS{idProduct}=="085a", TAG+="uaccess"
+
 LABEL="u2f_end"


### PR DESCRIPTION
I recently purchased [Feitian's multipass](https://www.ftsafe.com/products/FIDO/Multi) and noticed when I went to register it with github for 2FA, it didn't work. I found out it isn't in the udev rule list, so I thought I would add it and make a pull-request.