### PR TITLE
Bump buffer size

### DIFF
--- a/u2f-host/internal.h
+++ b/u2f-host/internal.h
@@ -56,7 +56,7 @@ struct u2fh_devs
 
 extern int debug;
 
-#define MAXDATASIZE 1024
+#define MAXDATASIZE 16384
 
 #define MAXFIXEDLEN 1024
 


### PR DESCRIPTION
We have a U2F device which uses large RSA keys so messages were not fitting in the 1Kb static buffer.
This should be enough for all U2F devices in the near future.