### PR TITLE
u2f-host: Fix refcount when adding json_objects

### DIFF
--- a/u2f-host/authenticate.c
+++ b/u2f-host/authenticate.c
@@ -55,9 +55,9 @@ prepare_response2 (const char *encstr, const char *bdstr, const char *input,
   if (jo == NULL)
     goto done;
 
-  json_object_object_add (jo, "signatureData", enc);
-  json_object_object_add (jo, "clientData", bd);
-  json_object_object_add (jo, "keyHandle", key);
+  json_object_object_add (jo, "signatureData", json_object_get (enc));
+  json_object_object_add (jo, "clientData", json_object_get (bd));
+  json_object_object_add (jo, "keyHandle", json_object_get (key));
 
   reply = json_object_to_json_string (jo);
   if (*response == NULL)
@@ -82,12 +82,9 @@ prepare_response2 (const char *encstr, const char *bdstr, const char *input,
 
 done:
   json_object_put (jo);
-  if (!jo)
-    {
-      json_object_put (enc);
-      json_object_put (bd);
-      json_object_put (key);
-    }
+  json_object_put (enc);
+  json_object_put (bd);
+  json_object_put (key);
 
   return rc;
 }

--- a/u2f-host/register.c
+++ b/u2f-host/register.c
@@ -41,8 +41,8 @@ prepare_response2 (const char *respstr, const char *bdstr, char **response,
   if (jo == NULL)
     goto done;
 
-  json_object_object_add (jo, "registrationData", resp);
-  json_object_object_add (jo, "clientData", bd);
+  json_object_object_add (jo, "registrationData", json_object_get (resp));
+  json_object_object_add (jo, "clientData", json_object_get (bd));
 
   reply = json_object_to_json_string (jo);
   if (*response == NULL)
@@ -67,11 +67,8 @@ prepare_response2 (const char *respstr, const char *bdstr, char **response,
 
 done:
   json_object_put (jo);
-  if (!jo)
-    {
-      json_object_put (resp);
-      json_object_put (bd);
-    }
+  json_object_put (resp);
+  json_object_put (bd);
 
   return rc;
 }

--- a/u2f-host/u2fmisc.c
+++ b/u2f-host/u2fmisc.c
@@ -70,9 +70,9 @@ prepare_browserdata (const char *challenge, const char *origin,
   if (jo == NULL)
     goto done;
 
-  json_object_object_add (jo, "challenge", chal);
-  json_object_object_add (jo, "origin", orig);
-  json_object_object_add (jo, "typ", typ);
+  json_object_object_add (jo, "challenge", json_object_get (chal));
+  json_object_object_add (jo, "origin", json_object_get (orig));
+  json_object_object_add (jo, "typ", json_object_get (typ));
 
   if (debug)
     {
@@ -93,12 +93,10 @@ prepare_browserdata (const char *challenge, const char *origin,
 
 done:
   json_object_put (jo);
-  if (!jo)
-    {
-      json_object_put (chal);
-      json_object_put (orig);
-      json_object_put (typ);
-    }
+  json_object_put (chal);
+  json_object_put (orig);
+  json_object_put (typ);
+
   return rc;
 }
 


### PR DESCRIPTION
This is documented in the json-c API [here](https://json-c.github.io/json-c/json-c-0.10/doc/html/json__object_8h.html#acc3628d97c6308dc967006e4268c4e7f) and [here](https://json-c.github.io/json-c/json-c-0.10/doc/html/json__object_8h.html#a04448b1c63173e1bfe49965835732075) and works fine with any released version of json-c.

Conditionalizing the calls to the json_object dtor is a hack, which obfuscates the improper use of the json-c API in this case.

Likewise https://github.com/Yubico/libu2f-server/pull/31.