### PR TITLE
Add Google Titan Key to u2f.rules.

### DIFF
--- a/70-old-u2f.rules
+++ b/70-old-u2f.rules
@@ -49,4 +49,7 @@ KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1ea8", ATTRS{idProduct
 # Nitrokey FIDO U2F
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="4287", GROUP="plugdev", MODE="0660"
 
+# Google Titan U2F
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="18d1", ATTRS{idProduct}=="5026", GROUP="plugdev", MODE="0660"
+
 LABEL="u2f_end"

--- a/70-u2f.rules
+++ b/70-u2f.rules
@@ -49,4 +49,7 @@ KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1ea8", ATTRS{idProduct
 # Nitrokey FIDO U2F
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="4287", TAG+="uaccess"
 
+# Google Titan U2F
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="18d1", ATTRS{idProduct}=="5026", TAG+="uaccess"
+
 LABEL="u2f_end"

--- a/u2f.conf.sample
+++ b/u2f.conf.sample
@@ -109,3 +109,13 @@ notify 100 {
 	match "product"		"0x4287";
 	action "chgrp u2f /dev/$cdev; chmod g+rw /dev/$cdev";
 };
+
+# Google Titan U2F
+notify 100 {
+	match "system"		"USB";
+	match "subsystem"	"DEVICE";
+	match "type"		"ATTACH";
+	match "vendor"		"0x18d1";
+	match "product"		"0x5026";
+	action "chgrp u2f /dev/$cdev; chmod g+rw /dev/$cdev";
+};


### PR DESCRIPTION
Titan is a U2F key internally used at Google. It complies with the U2F spec, so it makes sense to add it here.