### PR TITLE
Changes sleep logic to not sleep when not waiting on user input

### DIFF
--- a/u2f-host/authenticate.c
+++ b/u2f-host/authenticate.c
@@ -167,6 +167,11 @@ _u2fh_authenticate (u2fh_devs * devs,
   do
     {
       struct u2fdevice *dev;
+
+      if (iterations > 0 && len == 2 && memcmp (buf, NOTSATISFIED, 2) == 0)
+	{
+	  Sleep (1000);
+	}
       for (dev = devs->first; dev != NULL; dev = dev->next)
 	{
 	  unsigned char tmp_buf[MAXDATASIZE];
@@ -204,10 +209,6 @@ _u2fh_authenticate (u2fh_devs * devs,
       if (iterations++ > 15)
 	{
 	  return U2FH_TIMEOUT_ERROR;
-	}
-      if (len == 2 && memcmp (buf, NOTSATISFIED, 2) == 0)
-	{
-	  Sleep (1000);
 	}
     }
   while ((flags & U2FH_REQUEST_USER_PRESENCE)


### PR DESCRIPTION
The current behavior causes a 1-second sleep to occur when authenticating without a request for user presence. There is no mechanism to test for a valid token outside of a "presence-only" authentication. As a result, software wishing to ask the question, "is there a token that matches one of my key handles inserted" before taking some action [see this PR for example](https://github.com/Yubico/pam-u2f/pull/87), must wait a minimum full second to do so. This PR changes that behavior to sleep only on the second and subsequent iteration.

This can also be accomplished by adding a test for `flags & U2FH_ERQUEST_USER_PRESENCE` test to the existing sleep condition, however, it doesn't seem like the behavior shouldn't actually be "don't sleep when not asking for presence," but instead, "apparently we're iterating, so sleep before the next apdu is sent." Despite those being equivalent behavior now, that might not always be the case.