### PR TITLE
Adds max_id decrement to close_device

### DIFF
--- a/u2f-host/devs.c
+++ b/u2f-host/devs.c
@@ -171,6 +171,7 @@ close_device (u2fh_devs * devs, struct u2fdevice *dev)
 	    }
 	}
     }
+  devs->max_id--;
   return next;
 }
 


### PR DESCRIPTION
I just received an OnlyKey and while experimenting, I found an interesting bug. I haven't configured the onlykey, but I did have it inserted, while I also had my Yubikey (which is configured for u2f) inserted, and I could not login. As it turns out, every time the devices are discovered, the max_index gets incremented, only for the onlykey to fail discover, but max_id never gets decremented. So every time you devs_discover, the max_index inreases by one. Turns out it throws pam-u2f into an infinite loop, but this should be fixed here.

There's also a nasty delay while attempting to discover an unconfigured onlykey, but I'll work on that later.