### PR TITLE
add support for tomu board with chopstx u2f

### DIFF
--- a/70-old-u2f.rules
+++ b/70-old-u2f.rules
@@ -52,4 +52,7 @@ KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="20a0", ATTRS{idProduct
 # Google Titan U2F
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="18d1", ATTRS{idProduct}=="5026", GROUP="plugdev", MODE="0660"
 
+# Tomu board + chopstx U2F
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="cdab", GROUP="plugdev", MODE="0660"
+
 LABEL="u2f_end"

--- a/70-u2f.rules
+++ b/70-u2f.rules
@@ -52,4 +52,7 @@ KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="20a0", ATTRS{idProduct
 # Google Titan U2F
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="18d1", ATTRS{idProduct}=="5026", TAG+="uaccess"
 
+# Tomu board + chopstx U2F
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="cdab", TAG+="uaccess"
+
 LABEL="u2f_end"

--- a/u2f.conf.sample
+++ b/u2f.conf.sample
@@ -119,3 +119,13 @@ notify 100 {
 	match "product"		"0x5026";
 	action "chgrp u2f /dev/$cdev; chmod g+rw /dev/$cdev";
 };
+
+# Tomu board + chopstx U2F
+notify 100 {
+	match "system"		"USB";
+	match "subsystem"	"DEVICE";
+	match "type"		"ATTACH";
+	match "vendor"		"0x0483";
+	match "product"		"0xcdab";
+	action "chgrp u2f /dev/$cdev; chmod g+rw /dev/$cdev";
+};


### PR DESCRIPTION
This PR adds support for the [Tomu board](https://tomu.im), an open hardware token supported by [chopstx](https://github.com/im-tomu/chopstx/tree/efm32/u2f).

I tested the udev rules on my system and they work. The original udev rules can be found [here](https://github.com/im-tomu/chopstx/blob/efm32/u2f/README.md#update-udev-rules).