### PR TITLE
restricted length of strlens

### DIFF
--- a/u2f-host/authenticate.c
+++ b/u2f-host/authenticate.c
@@ -66,7 +66,7 @@ prepare_response2 (const char *encstr, const char *bdstr, const char *input,
     }
   else
     {
-      if (strlen (reply) >= *response_len)
+      if (strnlen (reply, (*response_len) + 1) >= *response_len)
 	{
 	  rc = U2FH_SIZE_ERROR;
 	  *response_len = strlen (reply) + 1;
@@ -100,7 +100,7 @@ prepare_response (const unsigned char *buf, int len, const char *bd,
 
   if (len > 2048)
     return U2FH_MEMORY_ERROR;
-  if (strlen (bd) > 2048)
+  if (strnlen (bd, 2048 + 1) > 2048)
     return U2FH_MEMORY_ERROR;
 
   base64_init_encodestate (&b64ctx);

--- a/u2f-host/register.c
+++ b/u2f-host/register.c
@@ -51,7 +51,7 @@ prepare_response2 (const char *respstr, const char *bdstr, char **response,
     }
   else
     {
-      if (strlen (reply) >= *response_len)
+      if (strnlen (reply, (*response_len) + 1) >= *response_len)
 	{
 	  rc = U2FH_SIZE_ERROR;
 	  *response_len = strlen (reply) + 1;
@@ -84,7 +84,7 @@ prepare_response (const unsigned char *buf, int len, const char *bd,
 
   if (len > 2048)
     return U2FH_MEMORY_ERROR;
-  if (strlen (bd) > 2048)
+  if (strnlen (bd, 2048 + 1) > 2048)
     return U2FH_MEMORY_ERROR;
 
   base64_init_encodestate (&b64ctx);

--- a/u2f-host/u2fmisc.c
+++ b/u2f-host/u2fmisc.c
@@ -80,7 +80,7 @@ prepare_browserdata (const char *challenge, const char *origin,
     }
 
   buf = json_object_to_json_string (jo);
-  len = strlen (buf);
+  len = strnlen (buf, (*outlen) + 1);
   if (len >= *outlen)
     {
       rc = U2FH_MEMORY_ERROR;
@@ -396,7 +396,7 @@ get_fixed_json_data (const char *jsonstr, const char *key, char *p,
   if (debug)
     fprintf (stderr, "JSON %s URL-B64: %s\n", key, urlb64);
 
-  if (strlen (urlb64) >= *len)
+  if (strnlen (urlb64, (*len) + 1) >= *len)
     {
       return U2FH_JSON_ERROR;
     }


### PR DESCRIPTION
Restricting the length of strlen prevents some DOS attacks.

I don't have a linux or window machine near by, I'm not sure if they have strnlen in modern versions or if autoconf is going to pick it up.
