### PR TITLE
Use a random nonce when initiating communication with the u2f device

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -98,6 +98,14 @@ AC_ARG_WITH([udevrulesdir],
   [], [])
 AC_SUBST([udevrulesdir], [$with_udevrulesdir])
 
+dnl check for random device
+AC_CACHE_CHECK(for random device, ac_cv_have_dev_random,
+[if test -r "/dev/urandom" ; then
+  ac_cv_have_dev_random=yes; else ac_cv_have_dev_random=no; fi])
+if test "$ac_cv_have_dev_random" = yes; then
+  AC_DEFINE([HAVE_DEV_URANDOM], 1, [Discovered a random device])
+fi
+
 PKG_CHECK_MODULES([UDEV], [udev >= 188],
                   udevrulesfile=70-u2f.rules,
                   udevrulesfile=70-old-u2f.rules,

--- a/windows.mk
+++ b/windows.mk
@@ -51,7 +51,7 @@ doit:
 	cp ../$(PACKAGE)-$(VERSION).tar.xz . && \
 	tar xfa $(PACKAGE)-$(VERSION).tar.xz && \
 	cd $(PACKAGE)-$(VERSION)/ && \
-	CC="$(HOST)-gcc -static-libgcc" PKG_CONFIG_PATH=$(PWD)/tmp$(ARCH)/root/lib/pkgconfig lt_cv_deplibs_check_method=pass_all ./configure --host=$(HOST) --build=x86_64-unknown-linux-gnu --prefix=$(PWD)/tmp$(ARCH)/root LDFLAGS=-L$(PWD)/tmp$(ARCH)/root/lib CPPFLAGS="-I$(PWD)/tmp$(ARCH)/root/include" && \
+	CC="$(HOST)-gcc -static-libgcc -lbcrypt" PKG_CONFIG_PATH=$(PWD)/tmp$(ARCH)/root/lib/pkgconfig lt_cv_deplibs_check_method=pass_all ./configure --host=$(HOST) --build=x86_64-unknown-linux-gnu --prefix=$(PWD)/tmp$(ARCH)/root LDFLAGS=-L$(PWD)/tmp$(ARCH)/root/lib CPPFLAGS="-I$(PWD)/tmp$(ARCH)/root/include" && \
 	make install $(CHECK) && \
 	cp COPYING $(PWD)/tmp$(ARCH)/root/licenses/$(PACKAGE).txt && \
 	cd .. && \


### PR DESCRIPTION
obtain_nonce() copied from libfido2.

This has been tested running u2f-host to register and authenticate on linux, macos and windows.
If this gets merged, one can also close PR #8 from 2014.
