### PR TITLE
Initialize the response buffer to 0

### DIFF
--- a/src/u2f-host.c
+++ b/src/u2f-host.c
@@ -33,7 +33,7 @@ main (int argc, char *argv[])
   struct gengetopt_args_info args_info;
   char challenge[BUFSIZ];
   size_t chal_len;
-  char response[2048];
+  char response[2048] = {0};
   size_t response_len = sizeof (response);
   u2fh_devs *devs = NULL;
   u2fh_cmdflags flags = 0;


### PR DESCRIPTION
Some of the code paths check if *response == NULL and if we end up at
the end main without anything actually setting the response we might
be printing random stack memory.

Found by static code checker: "line 135: Potentially uninitialized buffer 'response' used. Consider checking the first actual argument of the 'strlen' function."