### PR TITLE
Implement NFC support (also some questions)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq -y gengetopt help2man $EXTRA
 env:
-  - EXTRA="libjson0-dev libudev-dev libusb-1.0-0-dev libnfc-dev"
+  - EXTRA="libjson0-dev libudev-dev libusb-1.0-0-dev" CONFIG_FLAGS="--disable-libnfc"
+  - EXTRA="libjson0-dev libudev-dev libusb-1.0-0-dev libnfc-dev" CONFIG_FLAGS=""
 script:
   - ./build-aux/travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq -y gengetopt help2man $EXTRA
 env:
-  - EXTRA="libjson0-dev libudev-dev libusb-1.0-0-dev"
+  - EXTRA="libjson0-dev libudev-dev libusb-1.0-0-dev libnfc-dev"
 script:
   - ./build-aux/travis

--- a/build-aux/travis
+++ b/build-aux/travis
@@ -12,7 +12,7 @@ sudo ldconfig
 popd
 
 autoreconf -i
-./configure
+./configure $CONFIG_FLAGS
 make syntax-check
 
 if [ "x$ARCH" != "x" ]; then

--- a/configure.ac
+++ b/configure.ac
@@ -51,6 +51,17 @@ LIBS=$am_save_LIBS
 PKG_CHECK_MODULES([HIDAPI], [hidapi], [], [
   PKG_CHECK_MODULES([HIDAPI], [hidapi-hidraw])])
 
+AC_ARG_ENABLE([libnfc],
+  AS_HELP_STRING([--disable-libnfc], [Disable LibNFC @<:@default=yes@:>@]))
+if test "x$enable_libnfc" != "xno"; then
+  PKG_CHECK_MODULES([LIBNFC], [libnfc], [], [])
+  AC_DEFINE([FEATURE_LIBNFC], 1, [LibNFC enabled.])
+  FEATURE_LIBNFC=1
+else
+  FEATURE_LIBNFC=0
+fi
+AC_SUBST(FEATURE_LIBNFC)
+
 gl_INIT
 
 AC_ARG_ENABLE([gcc-warnings],

--- a/src/u2f-host.c
+++ b/src/u2f-host.c
@@ -145,15 +145,24 @@ process:
 	uint8_t command;
 	unsigned char out[2048];
 	size_t outlen = sizeof (out);
-	if (args_info.command_arg == NULL)
-	  {
-	    fprintf (stderr, "error: empty sendrecv command.\n");
-	    exit (EXIT_FAILURE);
-	  }
-	sscanf (args_info.command_arg, "%hhx", &command);
-	rc =
-	  u2fh_sendrecv (devs, 0, command, challenge, chal_len - 1, out,
-			 &outlen);
+#ifdef FEATURE_LIBNFC
+    if (!u2fh_nfc)
+      {
+#endif
+        if (args_info.command_arg == NULL)
+          {
+            fprintf (stderr, "error: empty sendrecv command.\n");
+            exit (EXIT_FAILURE);
+          }
+        sscanf (args_info.command_arg, "%hhx", &command);
+        rc = u2fh_sendrecv (devs, 0, command, challenge, chal_len - 1, out, &outlen);
+#ifdef FEATURE_LIBNFC
+      }
+    else
+      {
+        rc = u2fh_nfc_sendrecv (nfc_devs, challenge, chal_len - 1, out, &outlen);
+      }
+#endif
       }
       break;
     case action__NULL:

--- a/u2f-host/CMakeLists.txt
+++ b/u2f-host/CMakeLists.txt
@@ -28,7 +28,7 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR})
 # ==========
 # Source files
 # ==========
-set(SOURCE authenticate.c  cdecode.c  cencode.c  devs.c  error.c  global.c  register.c  u2fmisc.c  version.c)
+set(SOURCE authenticate.c  cdecode.c  cencode.c  devs.c  nfc_devs.c  error.c  global.c  register.c  u2fmisc.c  version.c)
 source_group(sources FILES ${SOURCE})
 include_directories(.)
 set(HEADERS u2f-host.h  u2f-host-types.h  internal.h)

--- a/u2f-host/Makefile.am
+++ b/u2f-host/Makefile.am
@@ -26,10 +26,10 @@ libu2f_host_la_SOURCES = u2f-host.h u2f-host-types.h u2f-host-version.h
 libu2f_host_la_SOURCES += internal.h
 libu2f_host_la_SOURCES += u2f-host.pc.in u2f-host.map
 libu2f_host_la_SOURCES += global.c version.c error.c
-libu2f_host_la_SOURCES += devs.c register.c authenticate.c u2fmisc.c
+libu2f_host_la_SOURCES += devs.c nfc_devs.c register.c authenticate.c u2fmisc.c
 libu2f_host_la_SOURCES += inc/u2f.h inc/u2f_hid.h
 
-libu2f_host_la_LIBADD = $(HIDAPI_LIBS) $(LIBJSON_LIBS)
+libu2f_host_la_LIBADD = $(HIDAPI_LIBS) $(LIBJSON_LIBS) $(LIBNFC_LIBS)
 libu2f_host_la_LIBADD += libu2f_b64.la
 libu2f_host_la_LIBADD += ../gl/libgnu.la
 

--- a/u2f-host/internal.h
+++ b/u2f-host/internal.h
@@ -22,6 +22,10 @@
 #include <hidapi.h>
 #include <stdio.h>
 
+#ifdef FEATURE_LIBNFC
+#include <nfc/nfc.h>
+#endif
+
 #include "inc/u2f.h"
 #include "inc/u2f_hid.h"
 
@@ -53,6 +57,44 @@ struct u2fh_devs
   unsigned max_id;
   struct u2fdevice *first;
 };
+
+#ifdef FEATURE_LIBNFC
+
+#define NFC_MAX_NUM_CONTROLLERS 4
+#define NFC_MAX_RESPONSE_LEN 2048
+#define NFC_TAG_NAME 0x71
+#define NFC_TAG_VERSION 0x79
+#define NFC_U2F_AID                                \
+  {                                                \
+    0xA0, 0x00, 0x00, 0x06, 0x47, 0x2F, 0x00, 0x01 \
+  }
+#define NFC_OATH_AID                               \
+  {                                                \
+    0xA0, 0x00, 0x00, 0x05, 0x27, 0x21, 0x01, 0x01 \
+  }
+
+struct u2fnfcdevice
+{
+  struct u2fnfcdevice *next;
+  nfc_device *pnd;
+  int skipped;
+  uint8_t versionMajor;
+  uint8_t versionMinor;
+  uint8_t versionBuild;
+};
+
+struct u2fh_nfc_devs
+{
+  unsigned max_id;
+  nfc_context *context;
+  struct u2fnfcdevice *first;
+};
+
+u2fh_rc send_apdu_nfc (nfc_device *pnd, uint8_t cla, uint8_t ins, uint8_t p1,
+                       uint8_t p2, const unsigned char *data, uint8_t data_len,
+                       uint8_t *resp, size_t *resp_len);
+
+#endif
 
 extern int debug;
 

--- a/u2f-host/internal.h
+++ b/u2f-host/internal.h
@@ -90,6 +90,9 @@ struct u2fh_nfc_devs
   struct u2fnfcdevice *first;
 };
 
+u2fh_rc send_apdu_nfc_compat (struct u2fnfcdevice *dev, int cmd,
+                              const unsigned char *data, size_t data_len,
+                              int p1, unsigned char *out, size_t *out_len);
 u2fh_rc send_apdu_nfc (nfc_device *pnd, uint8_t cla, uint8_t ins, uint8_t p1,
                        uint8_t p2, const unsigned char *data, uint8_t data_len,
                        uint8_t *resp, size_t *resp_len);

--- a/u2f-host/internal.h
+++ b/u2f-host/internal.h
@@ -90,6 +90,8 @@ struct u2fh_nfc_devs
   struct u2fnfcdevice *first;
 };
 
+u2fh_rc card_transmit (nfc_device *pnd, const uint8_t *capdu,
+                       const size_t capdu_len, uint8_t *rapdu, size_t *rapdu_len);
 u2fh_rc send_apdu_nfc_compat (struct u2fnfcdevice *dev, int cmd,
                               const unsigned char *data, size_t data_len,
                               int p1, unsigned char *out, size_t *out_len);

--- a/u2f-host/nfc_devs.c
+++ b/u2f-host/nfc_devs.c
@@ -10,8 +10,8 @@
   if (debug)          \
   fprintf (stderr, (f_), ##__VA_ARGS__)
 
-int
-card_transmit (nfc_device *pnd, uint8_t *capdu, size_t capdu_len,
+u2fh_rc
+card_transmit (nfc_device *pnd, const uint8_t *capdu, const size_t capdu_len,
                uint8_t *rapdu, size_t *rapdu_len)
 {
   int res;
@@ -35,7 +35,7 @@ card_transmit (nfc_device *pnd, uint8_t *capdu, size_t capdu_len,
     }
   if (res < 0)
     {
-      return -1;
+      return U2FH_TRANSPORT_ERROR;
     }
   *rapdu_len = total_res + 2;
 
@@ -44,7 +44,7 @@ card_transmit (nfc_device *pnd, uint8_t *capdu, size_t capdu_len,
     dlog ("%02x ", rapdu[pos]);
   dlog ("\n");
 
-  return 0;
+  return U2FH_OK;
 }
 
 u2fh_rc
@@ -61,8 +61,8 @@ send_apdu_nfc (nfc_device *pnd, uint8_t cla, uint8_t ins, uint8_t p1, uint8_t p2
   memcpy (&msg[5], data, data_len);
   ret = card_transmit (pnd, msg, 4 + 1 + data_len, resp, resp_len);
   free (msg);
-  if (ret != 0)
-    return U2FH_TRANSPORT_ERROR;
+  if (ret != U2FH_OK)
+    return ret;
   if (*resp_len < 2 || resp[*resp_len - 2] != 0x90 || resp[*resp_len - 1] != 0x00)
     {
       return U2FH_AUTHENTICATOR_ERROR;

--- a/u2f-host/nfc_devs.c
+++ b/u2f-host/nfc_devs.c
@@ -1,0 +1,239 @@
+#include <config.h>
+
+#ifdef FEATURE_LIBNFC
+#include "internal.h"
+
+#include <nfc/nfc.h>
+#include <stdlib.h>
+
+#define dlog(f_, ...) \
+  if (debug)          \
+  fprintf (stderr, (f_), ##__VA_ARGS__)
+
+int
+card_transmit (nfc_device *pnd, uint8_t *capdu, size_t capdu_len,
+               uint8_t *rapdu, size_t *rapdu_len)
+{
+  int res;
+  int total_res = 0;
+  uint8_t cmd_get_resp[4] = { capdu[0], 0xC0, 0x00, 0x00 };
+
+  size_t pos;
+  dlog ("=> ");
+  for (pos = 0; pos < capdu_len; pos++)
+    dlog ("%02x ", capdu[pos]);
+  dlog ("\n");
+
+  memset (rapdu, 0, *rapdu_len);
+  while ((res = nfc_initiator_transceive_bytes (
+           pnd, total_res > 0 ? cmd_get_resp : capdu, total_res > 0 ? 4 : capdu_len,
+           &rapdu[total_res], *rapdu_len - total_res, 1000)) >= 0)
+    {
+      total_res += res - 2;
+      if (rapdu[total_res] != 0x61)
+        break;
+    }
+  if (res < 0)
+    {
+      return -1;
+    }
+  *rapdu_len = total_res + 2;
+
+  dlog ("<= ");
+  for (pos = 0; pos < *rapdu_len; pos++)
+    dlog ("%02x ", rapdu[pos]);
+  dlog ("\n");
+
+  return 0;
+}
+
+u2fh_rc
+send_apdu_nfc (nfc_device *pnd, uint8_t cla, uint8_t ins, uint8_t p1, uint8_t p2,
+               const unsigned char *data, uint8_t data_len, uint8_t *resp, size_t *resp_len)
+{
+  uint8_t *msg = malloc (4 + 1 + data_len);
+  int ret;
+  msg[0] = cla;
+  msg[1] = ins;
+  msg[2] = p1;
+  msg[3] = p2;
+  msg[4] = data_len;
+  memcpy (&msg[5], data, data_len);
+  ret = card_transmit (pnd, msg, 4 + 1 + data_len, resp, resp_len);
+  free (msg);
+  if (ret != 0)
+    return U2FH_TRANSPORT_ERROR;
+  if (*resp_len < 2 || resp[*resp_len - 2] != 0x90 || resp[*resp_len - 1] != 0x00)
+    {
+      return U2FH_AUTHENTICATOR_ERROR;
+    }
+  return U2FH_OK;
+}
+
+u2fh_rc
+parse_tlv (const uint8_t data[], const size_t data_len, const uint8_t tag,
+           size_t *offset, size_t *len)
+{
+  size_t pos = 0;
+  while (pos < data_len)
+    {
+      if (data[pos] == tag)
+        {
+          *len = data[pos + 1];
+          *offset = pos + 2;
+          return U2FH_OK;
+        }
+      pos += data[pos + 1] + 2;
+    }
+  return U2FH_AUTHENTICATOR_ERROR;
+}
+
+u2fh_rc
+u2fh_nfc_devs_init (u2fh_nfc_devs **devs)
+{
+  u2fh_nfc_devs *devices;
+  devices = malloc (sizeof (*devices));
+  *devs = devices;
+
+  size_t num_devs;
+  size_t i;
+  nfc_device *pnd;
+  nfc_connstring nfc_connstrings[NFC_MAX_NUM_CONTROLLERS];
+  nfc_context *context;
+  struct u2fnfcdevice *dev;
+  struct u2fnfcdevice *curr_dev;
+
+  devices->max_id = 0;
+
+  nfc_init (&context);
+  devices->context = context;
+  num_devs = nfc_list_devices (context, nfc_connstrings, NFC_MAX_NUM_CONTROLLERS);
+  if (!num_devs)
+    return U2FH_NO_U2F_DEVICE;
+
+  const nfc_modulation nm = {
+    .nmt = NMT_ISO14443A,
+    .nbr = NBR_106,
+  };
+  nfc_target ant[1];
+
+  if (num_devs > NFC_MAX_NUM_CONTROLLERS)
+    num_devs = NFC_MAX_NUM_CONTROLLERS;
+  for (i = 0; i < num_devs; i++)
+    {
+      pnd = nfc_open (context, nfc_connstrings[i]);
+      if (pnd != NULL)
+        {
+          if (nfc_initiator_list_passive_targets (pnd, nm, ant, 1) > 0)
+            {
+              curr_dev = malloc (sizeof (*curr_dev));
+              curr_dev->next = NULL;
+              curr_dev->skipped = 0;
+              curr_dev->pnd = pnd;
+              if (devices->max_id)
+                {
+                  curr_dev->next = dev;
+                }
+              else
+                {
+                  devices->first = curr_dev;
+                }
+              dev = curr_dev;
+              devices->max_id++;
+            }
+          else
+            {
+              nfc_close (pnd);
+            }
+        }
+    }
+  if (!devices->max_id)
+    return U2FH_NO_U2F_DEVICE;
+  return U2FH_OK;
+}
+
+u2fh_rc
+u2fh_nfc_devs_discover (u2fh_nfc_devs *devices)
+{
+  struct u2fnfcdevice *dev;
+  int discovered_devs = 0;
+
+  uint8_t aid_oath[] = NFC_OATH_AID;
+  uint8_t aid_u2f[] = NFC_U2F_AID;
+  uint8_t resp[NFC_MAX_RESPONSE_LEN];
+  size_t resp_len;
+  size_t version_offset;
+  size_t version_len;
+
+  dev = devices->first;
+  while (dev != NULL)
+    {
+      resp_len = NFC_MAX_RESPONSE_LEN;
+      if (send_apdu_nfc (dev->pnd, 0x00, 0xA4, 0x04, 0x00, aid_oath,
+                         sizeof (aid_oath), resp, &resp_len) < 0)
+        {
+          dev->skipped = 1;
+          dev = dev->next;
+          continue;
+        }
+      if (parse_tlv (resp, resp_len, NFC_TAG_VERSION, &version_offset, &version_len) < 0 ||
+          version_len != 3)
+        {
+          dev->skipped = 1;
+          dev = dev->next;
+          continue;
+        }
+      dev->versionMajor = resp[version_offset++];
+      dev->versionMinor = resp[version_offset++];
+      dev->versionBuild = resp[version_offset];
+      resp_len = NFC_MAX_RESPONSE_LEN;
+      if (send_apdu_nfc (dev->pnd, 0x00, 0xA4, 0x04, 0x00, aid_u2f,
+                         sizeof (aid_u2f), resp, &resp_len) < 0)
+        {
+          dev->skipped = 1;
+        }
+      discovered_devs++;
+      dev = dev->next;
+    }
+  if (!discovered_devs)
+    return U2FH_NO_U2F_DEVICE;
+  return U2FH_OK;
+}
+
+struct u2fnfcdevice *
+get_nfc_device (u2fh_nfc_devs *devices)
+{
+  struct u2fnfcdevice *dev;
+  dev = devices->first;
+  while (dev->skipped && dev->next != NULL)
+    {
+      dev = dev->next;
+    }
+  return dev;
+}
+
+static void
+close_nfc_devices (u2fh_nfc_devs *devices)
+{
+  struct u2fnfcdevice *dev;
+  struct u2fnfcdevice *curr;
+  dev = devices->first;
+  while (dev != NULL)
+    {
+      curr = dev;
+      dev = dev->next;
+      nfc_close (curr->pnd);
+      free (curr);
+    }
+}
+
+void
+u2fh_nfc_devs_done (u2fh_nfc_devs *devices)
+{
+  close_nfc_devices (devices);
+  nfc_exit (devices->context);
+
+  free (devices);
+}
+
+#endif

--- a/u2f-host/u2f-host-types.h
+++ b/u2f-host/u2f-host-types.h
@@ -67,5 +67,8 @@ typedef enum
 } u2fh_cmdflags;
 
 typedef struct u2fh_devs u2fh_devs;
+#ifdef FEATURE_LIBNFC
+typedef struct u2fh_nfc_devs u2fh_nfc_devs;
+#endif
 
 #endif

--- a/u2f-host/u2f-host.h
+++ b/u2f-host/u2f-host.h
@@ -60,6 +60,9 @@ extern "C"
   U2FH_EXPORT u2fh_rc u2fh_nfc_devs_discover (u2fh_nfc_devs *devices);
   U2FH_EXPORT struct u2fnfcdevice *get_nfc_device (u2fh_nfc_devs *devices);
   U2FH_EXPORT void u2fh_nfc_devs_done (u2fh_nfc_devs *devices);
+  U2FH_EXPORT u2fh_rc u2fh_nfc_sendrecv (u2fh_nfc_devs *nfc_devs,
+                                         const unsigned char *send, uint16_t send_len,
+                                         unsigned char *recv, size_t *recv_len);
 #endif
 
    U2FH_EXPORT u2fh_rc

--- a/u2f-host/u2f-host.h
+++ b/u2f-host/u2f-host.h
@@ -55,23 +55,42 @@ extern "C"
   U2FH_EXPORT u2fh_rc u2fh_devs_discover (u2fh_devs * devs, unsigned *max_index);
   U2FH_EXPORT void u2fh_devs_done (u2fh_devs * devs);
 
-  U2FH_EXPORT u2fh_rc u2fh_register (u2fh_devs * devs,
-				const char *challenge,
-				const char *origin,
-				char **response, u2fh_cmdflags flags);
+#ifdef FEATURE_LIBNFC
+  U2FH_EXPORT u2fh_rc u2fh_nfc_devs_init (u2fh_nfc_devs **devices);
+  U2FH_EXPORT u2fh_rc u2fh_nfc_devs_discover (u2fh_nfc_devs *devices);
+  U2FH_EXPORT struct u2fnfcdevice *get_nfc_device (u2fh_nfc_devs *devices);
+  U2FH_EXPORT void u2fh_nfc_devs_done (u2fh_nfc_devs *devices);
+#endif
+
+   U2FH_EXPORT u2fh_rc
+   u2fh_register (u2fh_devs *devs,
+#ifdef FEATURE_LIBNFC
+                  u2fh_nfc_devs *nfc_devs,
+#endif
+                  const char *challenge, const char *origin,
+                  char **response, u2fh_cmdflags flags);
 
   U2FH_EXPORT u2fh_rc u2fh_register2 (u2fh_devs * devs,
+#ifdef FEATURE_LIBNFC
+                                 u2fh_nfc_devs *nfc_devs,
+#endif
 				 const char *challenge,
 				 const char *origin,
 				 char *response, size_t * response_len,
 				 u2fh_cmdflags flags);
 
   U2FH_EXPORT u2fh_rc u2fh_authenticate (u2fh_devs * devs,
+#ifdef FEATURE_LIBNFC
+                    u2fh_nfc_devs *nfc_devs,
+#endif
 				    const char *challenge,
 				    const char *origin,
 				    char **response, u2fh_cmdflags flags);
 
   U2FH_EXPORT u2fh_rc u2fh_authenticate2 (u2fh_devs * devs,
+#ifdef FEATURE_LIBNFC
+                     u2fh_nfc_devs *nfc_devs,
+#endif
 				     const char *challenge,
 				     const char *origin,
 				     char *response, size_t * response_len,

--- a/u2f-host/u2f-host.map
+++ b/u2f-host/u2f-host.map
@@ -23,6 +23,11 @@ U2F_HOST_0.0
     u2fh_get_device_description;
     u2fh_global_done;
     u2fh_global_init;
+#ifdef FEATURS_LIBNFC
+    u2fh_nfc_devs_init;
+    u2fh_nfc_devs_discover;
+    u2fh_nfc_devs_done;
+#endif
     u2fh_is_alive;
     u2fh_register;
     u2fh_sendrecv;

--- a/u2f-host/u2f-host.map
+++ b/u2f-host/u2f-host.map
@@ -27,6 +27,7 @@ U2F_HOST_0.0
     u2fh_nfc_devs_init;
     u2fh_nfc_devs_discover;
     u2fh_nfc_devs_done;
+    u2fh_nfc_sendrecv;
 #endif
     u2fh_is_alive;
     u2fh_register;

--- a/u2f-host/u2fmisc.c
+++ b/u2f-host/u2fmisc.c
@@ -19,6 +19,9 @@
 #include "internal.h"
 
 #include <json.h>
+#ifdef FEATURE_LIBNFC
+#include <nfc/nfc.h>
+#endif
 
 #include "sha256.h"
 
@@ -323,6 +326,15 @@ u2fh_sendrecv (u2fh_devs * devs, unsigned index, uint8_t cmd,
   }
   return U2FH_OK;
 }
+
+#ifdef FEATURE_LIBNFC
+u2fh_rc
+send_apdu_nfc_compat (struct u2fnfcdevice *dev, int cmd, const unsigned char *data,
+                      size_t data_len, int p1, unsigned char *out, size_t *out_len)
+{
+  return send_apdu_nfc (dev->pnd, 0, cmd, p1, 0, data, data_len, out, out_len);
+}
+#endif
 
 u2fh_rc
 send_apdu (u2fh_devs * devs, int index, int cmd, const unsigned char *d,

--- a/u2f-host/u2fmisc.c
+++ b/u2f-host/u2fmisc.c
@@ -334,6 +334,19 @@ send_apdu_nfc_compat (struct u2fnfcdevice *dev, int cmd, const unsigned char *da
 {
   return send_apdu_nfc (dev->pnd, 0, cmd, p1, 0, data, data_len, out, out_len);
 }
+
+u2fh_rc
+u2fh_nfc_sendrecv (u2fh_nfc_devs *nfc_devs, const unsigned char *send,
+                   uint16_t send_len, unsigned char *recv, size_t *recv_len)
+{
+  struct u2fnfcdevice *nfc_dev;
+  int ret;
+
+  nfc_dev = get_nfc_device (nfc_devs);
+  if (!nfc_dev)
+    return U2FH_NO_U2F_DEVICE;
+  return card_transmit (nfc_dev->pnd, send, send_len, recv, recv_len);
+}
 #endif
 
 u2fh_rc


### PR DESCRIPTION
PR summary:

1. Uses [libnfc](https://github.com/nfc-tools/libnfc) for NFC communication
0. A configuration flag `--enable-libnfc` / `--disable-libnfc` was added
0. Currently NFC is only used when no YubiKey is connected via USB
0. `u2fh_sendrecv` was left untouched for now
0. Tested under Linux and macOS. Libnfc supports Windows but I guess packaging would be a little tricky

TODOs (not deal-breakers tho):

1. Add additional flags so that users can choose between USB and NFC
0. Improve error output. Currently it always prints a warning when no USB key is found even if NFC operations are successful later
0. ~Implement an NFC version of `u2fh_sendrecv`~
0. Write comments!

Questions:

1. How is this project actually *utilised*? It seems that both Chrome/Chromium and Firefox have their own implementations. Perhaps a browser extension that uses native messaging?
0. Inspired by Yubico Authenticator, [it selects the OATH applet and reads the firmware version and tag name from the response](https://github.com/Yubico/libu2f-host/pull/127/files#diff-eaeccaf5c7ee7ef19177e61bf714c680R172). But I wonder whether there's a more direct way to read properties and configurations via NFC? I went through the code of this project and YubiKey Personalisation Tool without getting an idea of how to convert the HIDAPI and libusb implementations to libnfc code.
0. What is the tag name in the response of OATH AID selection?
0. Actually where can I find any info about the NFC protocols for proprietary applets? It's somewhat just a black box with full of myths to me now :(