### PR TITLE
Add productId=0404 to udev rules

### DIFF
--- a/70-u2f.rules
+++ b/70-u2f.rules
@@ -17,7 +17,7 @@
 ACTION!="add|change", GOTO="u2f_end"
 
 # Yubico YubiKey
-KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1050", ATTRS{idProduct}=="0113|0114|0115|0116|0120|0200|0402|0403|0406|0407|0410", TAG+="uaccess", GROUP="plugdev", MODE="0660"
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1050", ATTRS{idProduct}=="0113|0114|0115|0116|0120|0200|0402|0403|0404|0406|0407|0410", TAG+="uaccess", GROUP="plugdev", MODE="0660"
 
 # Happlink (formerly Plug-Up) Security KEY
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="2581", ATTRS{idProduct}=="f1d0", TAG+="uaccess", GROUP="plugdev", MODE="0660"


### PR DESCRIPTION
```
[  820.550498] usb 1-1: New USB device found, idVendor=1050, idProduct=0404, bcdDevice= 5.12
[  820.550504] usb 1-1: New USB device strings: Mfr=1, Product=2, SerialNumber=0
[  820.550507] usb 1-1: Product: YubiKey CCID
[  820.550509] usb 1-1: Manufacturer: Yubico
```