### PR TITLE
Amend comment in fix for CVE-2019-9578

### DIFF
--- a/u2f-host/devs.c
+++ b/u2f-host/devs.c
@@ -303,7 +303,7 @@ init_device (u2fh_devs * devs, struct u2fdevice *dev)
        &resplen) == U2FH_OK)
     {
       int offs = sizeof (nonce);
-      /* the response has to be atleast 17 bytes, if it's more we discard that */
+      /* the response has to be at least 17 bytes, if it's more we discard that */
       if (resplen < 17)
 	{
 	  return U2FH_SIZE_ERROR;

--- a/u2f-host/devs.c
+++ b/u2f-host/devs.c
@@ -303,7 +303,7 @@ init_device (u2fh_devs * devs, struct u2fdevice *dev)
        &resplen) == U2FH_OK)
     {
       int offs = sizeof (nonce);
-      /* the response has to be at least 17 bytes, if it's more we discard that */
+      /* the response has to be at least 17 bytes, if it's less we discard it */
       if (resplen < 17)
 	{
 	  return U2FH_SIZE_ERROR;


### PR DESCRIPTION
- [x] Fix typo
- [x] Fix misleading comment (the response is discarded if it's too short, not if it's too long)

Thanks to Adam D. Barratt for also noticing the issue, which reminded me to send a fix.