### PR TITLE
Update 70-u2f.rules to include product id 0121

### DIFF
--- a/70-u2f.rules
+++ b/70-u2f.rules
@@ -17,7 +17,7 @@
 ACTION!="add|change", GOTO="u2f_end"
 
 # Yubico YubiKey
-KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1050", ATTRS{idProduct}=="0113|0114|0115|0116|0120|0200|0402|0403|0406|0407|0410", TAG+="uaccess", GROUP="plugdev", MODE="0660"
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1050", ATTRS{idProduct}=="0113|0114|0115|0116|0120|0121|0200|0402|0403|0406|0407|0410", TAG+="uaccess", GROUP="plugdev", MODE="0660"
 
 # Happlink (formerly Plug-Up) Security KEY
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="2581", ATTRS{idProduct}=="f1d0", TAG+="uaccess", GROUP="plugdev", MODE="0660"


### PR DESCRIPTION
I received a yubikey from google and noticed it had a product id 0121 not included.  