### PR TITLE
Adding GoTrust Idem Key to udev rules

### DIFF
--- a/70-u2f.rules
+++ b/70-u2f.rules
@@ -80,4 +80,7 @@ KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="311f", ATTRS{idProduct
 # OnlyKey (FIDO2 / U2F)
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1d50", ATTRS{idProduct}=="60fc", TAG+="uaccess", GROUP="plugdev", MODE="0660"
 
+# GoTrust Idem Key
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1fc9", ATTRS{idProduct}=="f143", TAG+="uaccess", GROUP="plugdev", MODE="0660"
+
 LABEL="u2f_end"

--- a/u2f.conf.sample
+++ b/u2f.conf.sample
@@ -139,3 +139,13 @@ notify 100 {
 	match "product"		"(0x5070|0x50b0)";
 	action "chgrp u2f /dev/$cdev; chmod g+rw /dev/$cdev";
 };
+
+# GoTrust Idem Key
+notify 100 {
+	match "system"		"USB";
+	match "subsystem"	"DEVICE";
+	match "type"		"ATTACH";
+	match "vendor"		"0x1fc9";
+	match "product"		"0xf143";
+	action "chgrp u2f /dev/$cdev; chmod g+rw /dev/$cdev";
+};


### PR DESCRIPTION
Output from dmesg on Arch Linux:
```
usb 1-1: New USB device found, idVendor=1fc9, idProduct=f143, bcdDevice= 1.06
usb 1-1: New USB device strings: Mfr=1, Product=2, SerialNumber=0
usb 1-1: Product: Idem Key
usb 1-1: Manufacturer: GoTrust
hid-generic 0003:1FC9:F143.0002: hiddev0,hidraw0: USB HID v1.00 Device [GoTrust Idem Key] on usb-0000:00:14.0-1/input1
```