### PR TITLE
udev: Add rules for MIRKey devices

### DIFF
--- a/70-u2f.rules
+++ b/70-u2f.rules
@@ -83,4 +83,7 @@ KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1d50", ATTRS{idProduct
 # GoTrust Idem Key
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1fc9", ATTRS{idProduct}=="f143", TAG+="uaccess", GROUP="plugdev", MODE="0660"
 
+# ellipticSecure MIRKey
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="a2ac", TAG+="uaccess", GROUP="plugdev", MODE="0660"
+
 LABEL="u2f_end"

--- a/u2f.conf.sample
+++ b/u2f.conf.sample
@@ -149,3 +149,13 @@ notify 100 {
 	match "product"		"0xf143";
 	action "chgrp u2f /dev/$cdev; chmod g+rw /dev/$cdev";
 };
+
+# ellipticSecure MIRKey
+notify 100 {
+	match "system"		"USB";
+	match "subsystem"	"DEVICE";
+	match "type"		"ATTACH";
+	match "vendor"		"0x0483";
+	match "product"		"0xa2ac";
+	action "chgrp u2f /dev/$cdev; chmod g+rw /dev/$cdev";
+};


### PR DESCRIPTION
This mirrors the rules added to libfido2: https://github.com/Yubico/libfido2/commit/27cb42f971788fab8f68c3dc0fa9be92daa6780d

Thanks!