### PR TITLE
Update Ledger's productIDs + add Ledger Blue

### DIFF
--- a/70-u2f.rules
+++ b/70-u2f.rules
@@ -65,8 +65,8 @@ KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1209", ATTRS{idProduct
 # Infineon FIDO
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="058b", ATTRS{idProduct}=="022d", TAG+="uaccess", GROUP="plugdev", MODE="0660"
 
-# Ledger Nano S and Nano X
-KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="2c97", ATTRS{idProduct}=="0001|0004", TAG+="uaccess", GROUP="plugdev", MODE="0660"
+# Ledger Blue, Nano S and Nano X
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="2c97", ATTRS{idProduct}=="0000|0001|0004|0005|0015|1005|1015|4005|4015", TAG+="uaccess", GROUP="plugdev", MODE="0660"
 
 # Kensington VeriMark
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="06cb", ATTRS{idProduct}=="0088", TAG+="uaccess", GROUP="plugdev", MODE="0660"


### PR DESCRIPTION
Following https://www.ledger.com/windows-10-update-sunsetting-u2f-tunnel-transport-for-ledger-devices/, all Ledger products have changed the productID they advertise.
There's now 2 different combinations commonly available per device: 
- HID + U2F -> xx05 
- HID + U2F + WebUSB-> xx15